### PR TITLE
Replace view with reshape for latents_2d

### DIFF
--- a/sam2/modeling/perceiver.py
+++ b/sam2/modeling/perceiver.py
@@ -295,7 +295,7 @@ class PerceiverResampler(nn.Module):
     def forward_2d(self, x):
         B, C, H, W = x.shape
 
-        latents_2d = self.latents_2d.unsqueeze(0).expand(B, -1, -1).view(-1, 1, C)
+        latents_2d = self.latents_2d.unsqueeze(0).expand(B, -1, -1).reshape(-1, 1, C)
 
         num_window = int(math.sqrt(self.num_latents_2d))
         window_size = H // num_window


### PR DESCRIPTION
Avoids errors such as:

"""
➜  transmot git:(main) python3 -m edgetam.main
configuration solved
model instantiated
checkpoint loaded
model ready
frame loading (JPEG): 100%|███████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 45.60it/s]
/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/sam2/sam2_video_predictor.py:961: UserWarning: cannot import name '_C' from 'sam2' (/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/sam2/__init__.py)

Skipping the post-processing step due to the error above. You can still use SAM 2 and it's OK to ignore the error above, although some post-processing functionality may be limited (which doesn't affect the results in most cases; see https://github.com/facebookresearch/sam2/blob/main/INSTALL.md).
  pred_masks_gpu = fill_holes_in_mask_scores(
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/mikel.brostrom/transmot/edgetam/main.py", line 176, in <module>
    main()
  File "/Users/mikel.brostrom/transmot/edgetam/main.py", line 99, in main
    result_frame, tracked_objects = edgetam_system.process_frame(frame, frame_idx)
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mikel.brostrom/transmot/edgetam/core.py", line 109, in process_frame
    for out_frame_idx, out_obj_ids, out_masks in self.predictor.propagate_in_video(
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 36, in generator_context
    response = gen.send(None)
               ^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/sam2/sam2_video_predictor.py", line 671, in propagate_in_video
    self.propagate_in_video_preflight(inference_state)
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/sam2/sam2_video_predictor.py", line 619, in propagate_in_video_preflight
    consolidated_out = self._consolidate_temp_output_across_obj(
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/sam2/sam2_video_predictor.py", line 543, in _consolidate_temp_output_across_obj
    maskmem_features, maskmem_pos_enc = self._run_memory_encoder(
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/sam2/sam2_video_predictor.py", line 998, in _run_memory_encoder
    maskmem_features, maskmem_pos_enc = self._encode_new_memory(
                                        ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/sam2/modeling/sam2_base.py", line 740, in _encode_new_memory
    maskmem_features, maskmem_pos_enc[0] = self.spatial_perceiver(
                                           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1739, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1750, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/sam2/modeling/perceiver.py", line 265, in forward
    latents_2d, pos_2d = self.forward_2d(x)
                         ^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/sam2/modeling/perceiver.py", line 298, in forward_2d
    latents_2d = self.latents_2d.unsqueeze(0).expand(B, -1, -1).view(-1, 1, C)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
"""